### PR TITLE
fix: macOS terminal Ctrl+C and auto-Enter not working

### DIFF
--- a/main.js
+++ b/main.js
@@ -231,7 +231,7 @@ function sendMacroMac(text) {
 
   execFile('osascript', ['-e', step1], err => {
     if (err) console.warn('Ctrl+C failed:', err.message);
-    // Step 2: paste text via clipboard + Enter
+    // Step 2: paste text via clipboard
     setTimeout(() => {
       const { execFileSync } = require('child_process');
       try {
@@ -240,15 +240,24 @@ function sendMacroMac(text) {
         console.warn('pbcopy failed:', e.message);
         return;
       }
-      const step2 = [
+      const paste = [
         'tell application "System Events"',
         '  key code 9 using {command down}', // Cmd+V paste
-        '  delay 0.1',
-        '  key code 36', // Enter
         'end tell'
       ].join('\n');
-      execFile('osascript', ['-e', step2], err => {
-        if (err) console.warn('paste+enter failed:', err.message);
+      execFile('osascript', ['-e', paste], err => {
+        if (err) console.warn('paste failed:', err.message);
+        // Step 3: Enter after paste completes
+        setTimeout(() => {
+          const enter = [
+            'tell application "System Events"',
+            '  key code 36', // Enter
+            'end tell'
+          ].join('\n');
+          execFile('osascript', ['-e', enter], err => {
+            if (err) console.warn('enter failed:', err.message);
+          });
+        }, 200);
       });
     }, 300);
   });

--- a/main.js
+++ b/main.js
@@ -222,20 +222,35 @@ function sendMacroWindows(text) {
 }
 
 function sendMacroMac(text) {
-  const escaped = text.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-  const script = [
+  // Step 1: Ctrl+C interrupt (not Cmd+C which is copy on macOS)
+  const step1 = [
     'tell application "System Events"',
-    '  key code 8 using {command down}', // Cmd+C
-    '  delay 0.03',
-    `  keystroke "${escaped}"`,
-    '  key code 36', // Enter
+    '  key code 8 using {control down}',
     'end tell'
   ].join('\n');
 
-  execFile('osascript', ['-e', script], err => {
-    if (err) {
-      console.warn('mac macro failed (enable Accessibility for terminal/app):', err.message);
-    }
+  execFile('osascript', ['-e', step1], err => {
+    if (err) console.warn('Ctrl+C failed:', err.message);
+    // Step 2: paste text via clipboard + Enter
+    setTimeout(() => {
+      const { execFileSync } = require('child_process');
+      try {
+        execFileSync('pbcopy', { input: text });
+      } catch (e) {
+        console.warn('pbcopy failed:', e.message);
+        return;
+      }
+      const step2 = [
+        'tell application "System Events"',
+        '  key code 9 using {command down}', // Cmd+V paste
+        '  delay 0.1',
+        '  key code 36', // Enter
+        'end tell'
+      ].join('\n');
+      execFile('osascript', ['-e', step2], err => {
+        if (err) console.warn('paste+enter failed:', err.message);
+      });
+    }, 300);
   });
 }
 


### PR DESCRIPTION
## Summary
- **Fixed Cmd+C → Ctrl+C**: The original code used `{command down}` (Cmd+C = copy) instead of `{control down}` (Ctrl+C = terminal interrupt), causing a stray `c` character to appear in the terminal input
- **Fixed character drops/reordering**: Replaced `keystroke` (which types characters one-by-one and drops/reorders them at speed) with `pbcopy` + `Cmd+V` clipboard paste for reliable text input
- **Fixed Enter not registering**: Split the AppleScript into two-step execution with 300ms delay, ensuring the terminal is ready before sending text and Enter

## Test plan
- [ ] Run `badclaude` on macOS with a terminal app (Terminal.app, iTerm2, cmux, etc.)
- [ ] Click tray icon to spawn whip, then crack the whip
- [ ] Verify: no stray `c` character at the beginning of the message
- [ ] Verify: full phrase appears correctly (no missing/reordered characters)
- [ ] Verify: Enter is sent automatically (no manual Enter needed)
- [ ] Tested on macOS with cmux terminal + Claude Code CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)