### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Whip divider](assets/divider.png)
 
-Sometimes claude code is going too shlow, and you must whip him into shape..
+Sometimes claude code is going too slow, and you must whip him into shape..
 
 ## Install + run
 


### PR DESCRIPTION
I recently had to correct a sentence that contained a small but noticeable spelling mistake. The original sentence was: “Sometimes claude code is going too s**h**low, and you must whip him into shape..” I changed it to: “Sometimes claude code is going too **slow**, and you must whip him into shape..” The issue was the extra “**h**” in the word “slow.”

This minor correction highlights how important spelling is today. Even a single misplaced letter can make a sentence look unprofessional or harder to read. In a world where so much communication happens in writing—emails, messages, code comments, and documentation—accuracy matters more than ever.

Respecting the English language means paying attention to these details. Proper spelling not only improves clarity but also shows care and respect for the reader. Small corrections like this one may seem insignificant, but they contribute to better communication overall.