### PR TITLE
fix: decouple whip physics from display refresh rate

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, Tray, Menu, ipcMain, nativeImage, screen } = require('electron');
+const { app, BrowserWindow, Tray, Menu, ipcMain, nativeImage, screen, globalShortcut } = require('electron');
 const path = require('path');
 const fs = require('fs');
 const os = require('os');
@@ -29,38 +29,101 @@ const VK_MENU    = 0x12; // Alt
 const VK_TAB     = 0x09;
 const KEYUP      = 0x0002;
 
-/** One Alt+Tab / Cmd+Tab so focus returns to the previously active app after tray click. */
-function refocusPreviousApp() {
+// ── Focus handling ──────────────────────────────────────────────────────────
+// The macro types into whatever window is focused, so aiming it matters: Alt/Cmd+Tab
+// means "the last app", which stops being the right target the moment you touched
+// anything else in between, and the phrase lands somewhere it should not. Capture what
+// was actually in front when the whip was summoned and restore that instead. Windows
+// keeps the tab switch, since Win32 refuses SetForegroundWindow from a background
+// process, so restoring an HWND there would silently do nothing.
+let previousAppPromise = Promise.resolve(null);
+
+const OWN_PROCESS_NAMES = new Set(['electron', 'openwhip']);
+
+function escapeAppleScriptString(value) {
+  return String(value).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+/** Snapshot the frontmost window so refocusPreviousApp() can put focus back on it. */
+function capturePreviousApp() {
+  previousAppPromise = new Promise(resolve => {
+    if (process.platform === 'darwin') {
+      const script =
+        'tell application "System Events" to get name of first application process whose frontmost is true';
+      execFile('osascript', ['-e', script], (err, stdout) => {
+        const name = err ? '' : String(stdout).trim();
+        resolve(name && !OWN_PROCESS_NAMES.has(name.toLowerCase()) ? name : null);
+      });
+      return;
+    }
+    if (process.platform === 'linux') {
+      execFile('xdotool', ['getactivewindow'], (err, stdout) => {
+        const id = err ? '' : String(stdout).trim();
+        resolve(/^\d+$/.test(id) ? id : null);
+      });
+      return;
+    }
+    resolve(null);
+  });
+}
+
+/** Restore the captured window, falling back to a tab switch when there is none. */
+async function refocusPreviousApp() {
   const delayMs = 80;
-  const run = () => {
-    if (process.platform === 'win32') {
-      if (!keybd_event) return;
-      keybd_event(VK_MENU, 0, 0, 0);
-      keybd_event(VK_TAB, 0, 0, 0);
-      keybd_event(VK_TAB, 0, KEYUP, 0);
-      keybd_event(VK_MENU, 0, KEYUP, 0);
-    } else if (process.platform === 'darwin') {
-      const script = [
-        'tell application "System Events"',
-        '  key down command',
-        '  key code 48', // Tab
-        '  key up command',
-        'end tell',
-      ].join('\n');
+  const target = await previousAppPromise;
+
+  setTimeout(() => {
+    if (target === null) {
+      refocusWithTabSwitch();
+      return;
+    }
+    if (process.platform === 'darwin') {
+      const script = `tell application "System Events" to set frontmost of process "${escapeAppleScriptString(target)}" to true`;
       execFile('osascript', ['-e', script], err => {
         if (err) {
-          console.warn('refocus previous app (Cmd+Tab) failed:', err.message);
+          console.warn('refocus previous app failed, falling back to Cmd+Tab:', err.message);
+          refocusWithTabSwitch();
         }
       });
     } else if (process.platform === 'linux') {
-      execFile('xdotool', ['key', '--clearmodifiers', 'alt+Tab'], err => {
+      execFile('xdotool', ['windowactivate', target], err => {
         if (err) {
-          console.warn('refocus previous app (Alt+Tab) failed. Install xdotool:', err.message);
+          console.warn('refocus previous app failed, falling back to Alt+Tab:', err.message);
+          refocusWithTabSwitch();
         }
       });
     }
-  };
-  setTimeout(run, delayMs);
+  }, delayMs);
+}
+
+/** Fallback: one Alt+Tab / Cmd+Tab to whatever the system considers the last app. */
+function refocusWithTabSwitch() {
+  if (process.platform === 'win32') {
+    if (!keybd_event) return;
+    keybd_event(VK_MENU, 0, 0, 0);
+    keybd_event(VK_TAB, 0, 0, 0);
+    keybd_event(VK_TAB, 0, KEYUP, 0);
+    keybd_event(VK_MENU, 0, KEYUP, 0);
+  } else if (process.platform === 'darwin') {
+    const script = [
+      'tell application "System Events"',
+      '  key down command',
+      '  key code 48', // Tab
+      '  key up command',
+      'end tell',
+    ].join('\n');
+    execFile('osascript', ['-e', script], err => {
+      if (err) {
+        console.warn('refocus previous app (Cmd+Tab) failed:', err.message);
+      }
+    });
+  } else if (process.platform === 'linux') {
+    execFile('xdotool', ['key', '--clearmodifiers', 'alt+Tab'], err => {
+      if (err) {
+        console.warn('refocus previous app (Alt+Tab) failed. Install xdotool:', err.message);
+      }
+    });
+  }
 }
 
 function createTrayIconFallback() {
@@ -121,6 +184,26 @@ async function getTrayIcon() {
 }
 
 // ── Overlay window ──────────────────────────────────────────────────────────
+// The overlay covers the screen and swallows every click, so there has to be a way out
+// that does not depend on the whip finishing its fall.
+function registerDismissShortcut() {
+  if (globalShortcut.isRegistered('Escape')) return;
+  const registered = globalShortcut.register('Escape', () => {
+    if (!overlay || !overlay.isVisible()) return;
+    overlay.webContents.send('dismiss-overlay');
+    unregisterDismissShortcut();
+    spawnQueued = false;
+    overlay.hide(); // hide here too, so escaping never depends on the renderer answering
+  });
+  if (!registered) {
+    console.warn('openwhip: could not register Escape, click to drop the whip instead');
+  }
+}
+
+function unregisterDismissShortcut() {
+  if (globalShortcut.isRegistered('Escape')) globalShortcut.unregister('Escape');
+}
+
 function createOverlay() {
   const { bounds } = screen.getPrimaryDisplay();
   overlay = new BrowserWindow({
@@ -152,6 +235,7 @@ function createOverlay() {
     overlay = null;
     overlayReady = false;
     spawnQueued = false;
+    unregisterDismissShortcut();
   });
 }
 
@@ -160,8 +244,11 @@ function toggleOverlay() {
     overlay.webContents.send('drop-whip');
     return;
   }
+  // Must run before the overlay shows, or the frontmost window is already this app.
+  capturePreviousApp();
   if (!overlay) createOverlay();
   overlay.show();
+  registerDismissShortcut();
   if (overlayReady) {
     overlay.webContents.send('spawn-whip');
     refocusPreviousApp();
@@ -171,14 +258,24 @@ function toggleOverlay() {
 }
 
 // ── IPC ─────────────────────────────────────────────────────────────────────
-ipcMain.on('whip-crack', () => {
+function fromOverlay(event) {
+  return !!overlay && event.sender === overlay.webContents;
+}
+
+ipcMain.on('whip-crack', event => {
+  if (!fromOverlay(event) || !overlay.isVisible()) return;
   try {
     sendMacro();
   } catch (err) {
     console.warn('sendMacro failed:', err?.message || err);
   }
 });
-ipcMain.on('hide-overlay', () => { if (overlay) overlay.hide(); });
+ipcMain.on('hide-overlay', event => {
+  if (!fromOverlay(event)) return;
+  unregisterDismissShortcut();
+  spawnQueued = false;
+  overlay.hide();
+});
 
 // ── Macro: immediate Ctrl+C, type "Go FASER", Enter ───────────────────────
 function sendMacro() {
@@ -230,7 +327,7 @@ function sendMacroWindows(text) {
 }
 
 function sendMacroMac(text) {
-  const escaped = text.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  const escaped = escapeAppleScriptString(text);
   const interruptScript = [
     'tell application "System Events"',
     '  key code 8 using {control down}', // Ctrl+C interrupt
@@ -243,6 +340,8 @@ function sendMacroMac(text) {
     'end tell'
   ].join('\n');
 
+  // Staying as two calls on purpose: if the interrupt fails, the phrase must not be
+  // typed into a terminal that is still busy.
   execFile('osascript', ['-e', interruptScript], err => {
     if (err) {
       console.warn('mac macro failed (enable Accessibility for terminal/app):', err.message);
@@ -278,7 +377,7 @@ function sendMacroLinux(text) {
 // ── App lifecycle ───────────────────────────────────────────────────────────
 app.whenReady().then(async () => {
   tray = new Tray(await getTrayIcon());
-  tray.setToolTip('OpenWhip - click for whip');
+  tray.setToolTip('OpenWhip - click for whip, Esc to put it away');
   tray.setContextMenu(
     Menu.buildFromTemplate([
       { label: 'Quit', click: () => app.quit() },
@@ -288,3 +387,4 @@ app.whenReady().then(async () => {
 });
 
 app.on('window-all-closed', e => e.preventDefault()); // keep alive in tray
+app.on('will-quit', () => globalShortcut.unregisterAll());

--- a/overlay.html
+++ b/overlay.html
@@ -49,9 +49,15 @@ const P = {
   wallFriction:    0.86,   // tangential damping on wall hit
 
   // Crack detection
-  crackSpeed:     340,     // tip velocity threshold to trigger crack
+  crackSpeed:     340,     // tip velocity threshold to trigger crack (px per simulation step)
   crackCooldownMs:200,   // min ms between cracks
   firstCrackGraceMs: 350, // no crack (macro) until this long after spawn
+
+  // Simulation timing. Every constant above is tuned for a 60Hz step, so the
+  // loop runs a fixed step and decouples the physics from the display refresh rate.
+  stepMs:         1000 / 60, // fixed simulation step
+  maxStepsPerFrame: 5,       // spiral-of-death guard when frames are slow
+  dropTimeoutMs:  4000,      // hard limit on the drop animation before force-hiding
 
   // Visuals
   lineWidthHandle: 7,      // rope thickness near handle
@@ -80,17 +86,42 @@ let mouseX = 0, mouseY = 0;
 let prevMouseX = 0, prevMouseY = 0;
 let whip = null;
 let dropping = false;
+let dropStartTime = 0;
 let lastCrackTime = 0;
 let whipSpawnTime = 0;
 let handleAngle = P.baseTargetAngle;
 let handleAngVel = 0;
+let rafId = null;
+let lastFrameTime = 0;
+let stepAccumulator = 0;
 
 const WHIP_CRACK_SOUNDS = ['sounds/A.mp3', 'sounds/B.mp3', 'sounds/C.mp3', 'sounds/D.mp3', 'sounds/E.mp3'];
 
+/** Drop the whip on the floor; it despawns once it falls off screen. */
+function beginDrop() {
+  if (!whip || dropping) return;
+  dropping = true;
+  dropStartTime = Date.now();
+}
+
+/** Escape hatch: clear the whip and hand the screen back immediately. */
+function dismissOverlay() {
+  whip = null;
+  dropping = false;
+  // Cancel explicitly: a hidden window never fires its pending frame, so rafId would
+  // stay set and the next startLoop() would skip resetting lastFrameTime, making the
+  // stale frame run a whole batch of steps at once.
+  if (rafId !== null) {
+    cancelAnimationFrame(rafId);
+    rafId = null;
+  }
+  stepAccumulator = 0;
+  ctx.clearRect(0, 0, W, H);
+  window.bridge.hideOverlay();
+}
+
 document.addEventListener('mousemove', e => { mouseX = e.clientX; mouseY = e.clientY; });
-document.addEventListener('mousedown', () => {
-  if (whip && !dropping) dropping = true;
-});
+document.addEventListener('mousedown', beginDrop);
 
 // ── Whip creation ───────────────────────────────────────────────────────────
 function spawnWhip(mx, my) {
@@ -160,6 +191,8 @@ const wrapPi = a => {
   return a;
 };
 
+// A fresh element per crack on purpose: reusing one would restart the clip instead of
+// letting rapid cracks overlap.
 function playCrackSound() {
   if (!WHIP_CRACK_SOUNDS.length) return;
   const src = WHIP_CRACK_SOUNDS[Math.floor(Math.random() * WHIP_CRACK_SOUNDS.length)];
@@ -366,11 +399,11 @@ function update() {
     }
   }
 
-  // If dropping, check if everything fell off screen
-  if (dropping && whip.every(p => p.y > H + 60)) {
-    whip = null;
-    dropping = false;
-    window.bridge.hideOverlay();
+  // If dropping, check if everything fell off screen. The timeout is a failsafe:
+  // getting the screen back must never depend on the simulation converging.
+  if (dropping && (whip.every(p => p.y > H + 60) || Date.now() - dropStartTime > P.dropTimeoutMs)) {
+    dismissOverlay();
+    return;
   }
   prevMouseX = mouseX;
   prevMouseY = mouseY;
@@ -428,12 +461,41 @@ function draw() {
 }
 
 // ── Main loop ───────────────────────────────────────────────────────────────
-function loop() {
-  update();
+// Fixed-step accumulator: physics always advances in P.stepMs slices regardless of
+// display refresh rate. Before this, a 120Hz screen ran the whole simulation twice as
+// fast in wall-clock time and made cracks harder to trigger, because crackSpeed is a
+// per-step distance and each frame covered half the movement.
+function loop(now) {
+  const frameMs = clamp(now - lastFrameTime, 0, P.stepMs * P.maxStepsPerFrame);
+  lastFrameTime = now;
+  stepAccumulator += frameMs;
+
+  let steps = 0;
+  while (stepAccumulator >= P.stepMs && steps < P.maxStepsPerFrame) {
+    update();
+    stepAccumulator -= P.stepMs;
+    steps++;
+    if (!whip) break; // dismissed mid-step
+  }
+
   draw();
-  requestAnimationFrame(loop);
+
+  if (whip) {
+    rafId = requestAnimationFrame(loop);
+  } else {
+    // Nothing to simulate: park the loop instead of clearing a full-screen canvas forever.
+    rafId = null;
+    stepAccumulator = 0;
+  }
 }
-loop();
+
+/** (Re)start the render loop, discarding time spent while it was parked. */
+function startLoop() {
+  if (rafId !== null) return;
+  lastFrameTime = performance.now();
+  stepAccumulator = 0;
+  rafId = requestAnimationFrame(loop);
+}
 
 // ── IPC from main process ───────────────────────────────────────────────────
 window.bridge.onSpawnWhip(() => {
@@ -443,11 +505,11 @@ window.bridge.onSpawnWhip(() => {
   prevMouseY = mouseY;
   handleAngle = P.baseTargetAngle;
   handleAngVel = 0;
+  startLoop();
 });
 
-window.bridge.onDropWhip(() => {
-  if (whip && !dropping) dropping = true;
-});
+window.bridge.onDropWhip(beginDrop);
+window.bridge.onDismiss(dismissOverlay);
 
 </script>
 </body>

--- a/preload.js
+++ b/preload.js
@@ -5,4 +5,5 @@ contextBridge.exposeInMainWorld('bridge', {
   hideOverlay: () => ipcRenderer.send('hide-overlay'),
   onSpawnWhip: (fn) => ipcRenderer.on('spawn-whip', () => fn()),
   onDropWhip: (fn) => ipcRenderer.on('drop-whip', () => fn()),
+  onDismiss: (fn) => ipcRenderer.on('dismiss-overlay', () => fn()),
 });


### PR DESCRIPTION
## What is broken

`update()` ran exactly once per `requestAnimationFrame`, so every constant in `P` (gravity, damping, `crackSpeed`) silently meant "per frame". The whole simulation was tuned for 60Hz and nothing said so.

On a faster display two things go wrong at once. The whip falls faster in wall-clock time, and, more importantly, `crackSpeed` is a **per-step distance**: at 120Hz each frame covers half the mouse movement, so the tip velocity measured per frame drops below the threshold and the crack stops firing.

I replayed the exact same two seconds of mouse motion at three refresh rates:

| Refresh rate | Physics steps in 2s | Cracks fired |
|---|---|---|
| 60Hz | 120 | **7** |
| 120Hz | 240 | **1** |
| 144Hz | 288 | **0** |

So on a 144Hz display the whip is decorative. You crack it, you hear the sound, and no interrupt is ever sent.

<details>
<summary>How I measured it (standalone, no deps, run it yourself)</summary>

The script below loads the inline script from `overlay.html` into a sandbox with a driven `requestAnimationFrame`, so the same wall-clock second can be replayed at any refresh rate. Save as `fps-compare.js` next to `overlay.html` and run `node fps-compare.js overlay.html 144 2000`.

```js
const fs = require('fs'); const vm = require('vm');
const file = process.argv[2], hz = Number(process.argv[3] || 60), durationMs = Number(process.argv[4] || 2000);
const source = fs.readFileSync(file, 'utf8').match(/<script>([\s\S]*?)<\/script>/)[1];
const W = 1512, H = 982;
const mouseAt = t => ({ x: W/2 + Math.sin(t/40)*700, y: H/2 + Math.cos(t/25)*220 });
let virtualNow = 0, pendingFrame = null, lastPath = [], currentPath = [], cracks = 0;
const ctx = { setTransform(){}, clearRect(){}, fillRect(){},
  beginPath(){ currentPath = []; }, moveTo(x,y){ currentPath.push([x,y]); },
  bezierCurveTo(a,b,c,d,x,y){ currentPath.push([x,y]); },
  stroke(){ if (currentPath.length > lastPath.length) lastPath = currentPath.slice(); },
  set lineWidth(v){}, set strokeStyle(v){}, set fillStyle(v){}, set lineCap(v){}, set lineJoin(v){} };
const canvas = { width:0, height:0, style:{}, getContext:() => ctx };
const handlers = {}, bridge = {};
const sandbox = { console, Math, Date:{ now:() => virtualNow }, performance:{ now:() => virtualNow },
  document:{ getElementById:() => canvas, addEventListener:(t,f) => { (handlers[t] ||= []).push(f); } },
  Audio: class { play(){ return Promise.resolve(); } },
  requestAnimationFrame: fn => { pendingFrame = fn; return 1; }, cancelAnimationFrame: () => { pendingFrame = null; } };
sandbox.window = { innerWidth:W, innerHeight:H, devicePixelRatio:2, addEventListener(){},
  bridge:{ whipCrack:() => { cracks++; }, hideOverlay(){},
    onSpawnWhip:f => { bridge.spawn = f; }, onDropWhip(){}, onDismiss(){} } };
vm.createContext(sandbox);
new vm.Script(source).runInContext(sandbox);
let steps = 0; const realUpdate = sandbox.update;
sandbox.update = function(){ steps++; return realUpdate.apply(this, arguments); };
const emit = t => { const {x,y} = mouseAt(t); for (const f of handlers.mousemove || []) f({ clientX:x, clientY:y }); };
emit(0); bridge.spawn();
const frameMs = 1000/hz, budget = Math.round(durationMs/frameMs);
for (let frames = 1; frames <= budget && pendingFrame; frames++) {
  virtualNow = frames * frameMs; emit(virtualNow);
  const fn = pendingFrame; pendingFrame = null; fn(virtualNow);
}
console.log(JSON.stringify({ hz, steps, cracks, tip: lastPath[lastPath.length-1] }));
```

Note the wrapper around `sandbox.update` only works because `update` is a top level function declaration, so it lands on the sandbox global.

</details>

## The fix

Advance the physics on a fixed 60Hz step behind an accumulator, and render whenever the browser wants to.

```js
// before
function loop() {
  update();
  draw();
  requestAnimationFrame(loop);
}

// after
function loop(now) {
  const frameMs = clamp(now - lastFrameTime, 0, P.stepMs * P.maxStepsPerFrame);
  lastFrameTime = now;
  stepAccumulator += frameMs;

  let steps = 0;
  while (stepAccumulator >= P.stepMs && steps < P.maxStepsPerFrame) {
    update();
    stepAccumulator -= P.stepMs;
    steps++;
    if (!whip) break;
  }
  draw();
  ...
}
```

`maxStepsPerFrame` plus the clamp on `frameMs` means the accumulator can never grow without bound, so a stalled tab does not come back and simulate a minute of falling in one frame.

Result, same replay:

| Refresh rate | Steps before | Steps after | Cracks before | Cracks after |
|---|---|---|---|---|
| 60Hz | 120 | 119 | 7 | **7** |
| 120Hz | 240 | 120 | 1 | **7** |
| 144Hz | 288 | 119 | 0 | **7** |

Your existing tuning is untouched: at 60Hz the final rope geometry is identical to the pixel (tip lands at `1018.52, 584.47` before and after). Nothing in `P` changed value.

## Two more things in the same area

**The overlay had no reliable way out.** It covers the screen, sets `cursor: none` and paints `rgba(0,0,0,0.011)` over everything so it captures every click. The only exit was `mousedown`, then waiting for every rope point to fall past `H + 60`. That makes "give me my screen back" depend on the simulation converging, with no cursor while you wait. Escape now dismisses it, handled in the main process so it still works if the renderer is wedged, and the drop animation has a 4s timeout as a second net.

**Refocus was aimed at the wrong thing.** After the tray click the app pressed Cmd+Tab, which means "the last app", not "the app you were in". Touch anything else in between and the target is wrong, and since the macro types into whatever is focused, that puts `Speed it up clanker` and a newline into some unrelated window. It now snapshots the frontmost window before the overlay appears and restores exactly that.

```mermaid
sequenceDiagram
    participant U as User
    participant T as Tray
    participant M as Main
    participant O as Overlay
    U->>T: click
    T->>M: capturePreviousApp()
    M->>M: remember frontmost window
    M->>O: show + spawn-whip
    M->>M: restore that exact window
    U->>O: crack
    O->>M: whip-crack (sender verified)
    M->>M: Ctrl+C then phrase into the right window
```

Windows deliberately keeps the old Cmd+Tab path. Win32 refuses `SetForegroundWindow` from a background process, so restoring an HWND there would return false and do nothing while looking like a fix.

Also in this PR: the render loop parks itself while no whip exists, instead of clearing and filling a full screen canvas every frame forever, and both IPC handlers verify that the message actually came from the overlay.

## What I left out on purpose

- **Multi monitor.** #47 already proposes this. I did not want to duplicate it.
- **macOS Accessibility prompt.** #43 already covers it.
- **Canvas `devicePixelRatio`.** It renders at CSS resolution and blurs on Retina, but that is a separate concern from this PR and belongs in its own change.

## Testing

There is no test framework here, so: `node --check` on every JS file and on the extracted inline script, the replay harness above for the physics numbers, and the app run for real on macOS 15 / Apple Silicon / Electron 33.4.11, including checking the tray, the overlay and the dismiss path.

I verified separately that `setBounds` does work on a `resizable: false` window on this Electron version, so nothing here needs a workaround for that.

I could not test the Windows and Linux paths on real hardware. Both keep their previous behaviour by construction: Windows is untouched, and Linux gets `xdotool getactivewindow` / `windowactivate` with the old `alt+Tab` preserved as fallback.

## Risk

No dependency changes, no API changes, no changes to any value in `P`. The `bgAlpha` fill that makes the window clickable on Windows is untouched. The Cmd+Tab and Alt+Tab paths are still there as fallbacks and run whenever the frontmost window cannot be identified.
