### PR TITLE
Wayland: type through wtype and release the overlay's keyboard grab

### DIFF
--- a/main.js
+++ b/main.js
@@ -29,6 +29,37 @@ const VK_MENU    = 0x12; // Alt
 const VK_TAB     = 0x09;
 const KEYUP      = 0x0002;
 
+/**
+ * sway: remember which window was focused when the whip spawned.
+ *
+ * Alt+Tab is the wrong tool under a tiling compositor - there is no
+ * most-recently-used stack to walk. Worse, sway defaults to
+ * focus_follows_mouse=yes, and cracking a whip means flinging the pointer across
+ * the screen, so focus lands on whatever it passed over and the macro types
+ * there. Recording the target up front and focusing it explicitly before typing
+ * makes it deterministic no matter where the cursor ends up.
+ */
+let swayTargetConId = null;
+
+function captureSwayFocus() {
+  if (process.platform !== 'linux' || !process.env.WAYLAND_DISPLAY) return;
+  execFile('swaymsg', ['-t', 'get_tree'], (err, stdout) => {
+    if (err) return; // not sway (Hyprland, GNOME, ...) - fall back to whatever has focus
+    try {
+      const find = n =>
+        n.focused
+          ? n.id
+          : [...(n.nodes || []), ...(n.floating_nodes || [])].reduce(
+              (found, child) => found || find(child),
+              null
+            );
+      swayTargetConId = find(JSON.parse(stdout));
+    } catch {
+      swayTargetConId = null;
+    }
+  });
+}
+
 /** One Alt+Tab / Cmd+Tab so focus returns to the previously active app after tray click. */
 function refocusPreviousApp() {
   const delayMs = 80;
@@ -52,7 +83,10 @@ function refocusPreviousApp() {
           console.warn('refocus previous app (Cmd+Tab) failed:', err.message);
         }
       });
-    } else if (process.platform === 'linux') {
+    } else if (process.platform === 'linux' && !process.env.WAYLAND_DISPLAY) {
+      // Skipped under Wayland: the tray lives in a layer-shell bar and the overlay
+      // is focusable:false, so neither ever takes keyboard focus and there is
+      // nothing to hand back. sway also has no MRU stack for Alt+Tab to walk.
       execFile('xdotool', ['key', '--clearmodifiers', 'alt+Tab'], err => {
         if (err) {
           console.warn('refocus previous app (Alt+Tab) failed. Install xdotool:', err.message);
@@ -160,6 +194,8 @@ function toggleOverlay() {
     overlay.webContents.send('drop-whip');
     return;
   }
+  // Before anything is shown or the pointer starts moving, note who we are whipping.
+  captureSwayFocus();
   if (!overlay) createOverlay();
   overlay.show();
   if (overlayReady) {
@@ -260,6 +296,67 @@ function sendMacroMac(text) {
 }
 
 function sendMacroLinux(text) {
+  // xdotool drives XTEST, which a wlroots compositor does not route to Wayland
+  // clients - under sway it reaches XWayland windows and nothing else, so whipping
+  // a Wayland-native terminal silently does nothing. wtype(1) speaks the
+  // virtual-keyboard Wayland protocol, which does get through. Pick per session.
+  if (process.env.WAYLAND_DISPLAY) {
+    sendMacroWayland(text);
+  } else {
+    sendMacroX11(text);
+  }
+}
+
+function sendMacroWayland(text) {
+  // The overlay is created with alwaysOnTop 'screen-saver', which Electron maps to
+  // a layer-shell surface holding keyboard interactivity. While it is up, sway
+  // routes the virtual keyboard to IT - not to the window sway still reports as
+  // focused - so every keystroke vanishes into the whip. Dropping the surface for
+  // the ~200ms the macro takes is what actually releases the keyboard; refocusing
+  // alone is not enough. Put it straight back so the whip survives the crack.
+  const wasVisible = Boolean(overlay && overlay.isVisible());
+  let restored = false;
+  const restoreOverlay = () => {
+    if (restored) return;
+    restored = true;
+    if (wasVisible && overlay && !overlay.isDestroyed()) overlay.show();
+  };
+  if (wasVisible) overlay.hide();
+
+  const run = (args, next) =>
+    execFile('wtype', args, err => {
+      if (err) {
+        console.warn('wayland macro failed. Install wtype:', err.message);
+        restoreOverlay();
+        return;
+      }
+      if (next) next();
+    });
+
+  // Text goes after `--` so a phrase starting with `-` is never read as an option,
+  // and through execFile's argv so there is no shell quoting to get wrong. The
+  // pause lets the interrupted TUI redraw its prompt before we type into it -
+  // without it the first characters land while the app is still tearing down.
+  const whip = () =>
+    run(['-M', 'ctrl', '-k', 'c', '-m', 'ctrl'], () =>
+      setTimeout(
+        () => run(['-d', '12', '--', text], () => run(['-k', 'Return'], restoreOverlay)),
+        120
+      )
+    );
+
+  // Hand focus back to whoever we are whipping. Without this the keystrokes follow
+  // the pointer under focus_follows_mouse and land in whichever window it crossed.
+  if (swayTargetConId != null) {
+    execFile('swaymsg', [`[con_id=${swayTargetConId}]`, 'focus'], () =>
+      setTimeout(whip, 40)
+    );
+  } else {
+    whip();
+  }
+}
+
+function sendMacroX11(text) {
   execFile(
     'xdotool',
     [

--- a/main.js
+++ b/main.js
@@ -41,6 +41,9 @@ const KEYUP      = 0x0002;
  */
 let swayTargetConId = null;
 
+/** True while a Wayland macro is running - see sendMacroWayland. */
+let macroInFlight = false;
+
 function captureSwayFocus() {
   if (process.platform !== 'linux' || !process.env.WAYLAND_DISPLAY) return;
   execFile('swaymsg', ['-t', 'get_tree'], (err, stdout) => {
@@ -308,6 +311,15 @@ function sendMacroLinux(text) {
 }
 
 function sendMacroWayland(text) {
+  // One macro is three wtype spawns plus a 120ms pause plus the refocus - well over
+  // overlay.html's 200ms crack cooldown, so an enthusiastic whipper re-enters this
+  // before the previous run has finished. Concurrent wtype invocations each create
+  // their own virtual keyboard and interleave, which shows up as phrases running
+  // together with no Enter between them and words truncated mid-word. Drop cracks
+  // that arrive while one is still in flight rather than stacking them.
+  if (macroInFlight) return;
+  macroInFlight = true;
+
   // The overlay is created with alwaysOnTop 'screen-saver', which Electron maps to
   // a layer-shell surface holding keyboard interactivity. While it is up, sway
   // routes the virtual keyboard to IT - not to the window sway still reports as
@@ -315,19 +327,25 @@ function sendMacroWayland(text) {
   // the ~200ms the macro takes is what actually releases the keyboard; refocusing
   // alone is not enough. Put it straight back so the whip survives the crack.
   const wasVisible = Boolean(overlay && overlay.isVisible());
-  let restored = false;
-  const restoreOverlay = () => {
-    if (restored) return;
-    restored = true;
+  let finished = false;
+  let watchdog = null;
+  const finish = () => {
+    if (finished) return;
+    finished = true;
+    clearTimeout(watchdog);
     if (wasVisible && overlay && !overlay.isDestroyed()) overlay.show();
+    macroInFlight = false;
   };
+  // Belt and braces: if wtype ever wedges, this stops one stuck run from leaving
+  // the whip permanently unable to crack again.
+  watchdog = setTimeout(finish, 3000);
   if (wasVisible) overlay.hide();
 
   const run = (args, next) =>
     execFile('wtype', args, err => {
       if (err) {
         console.warn('wayland macro failed. Install wtype:', err.message);
-        restoreOverlay();
+        finish();
         return;
       }
       if (next) next();
@@ -340,7 +358,7 @@ function sendMacroWayland(text) {
   const whip = () =>
     run(['-M', 'ctrl', '-k', 'c', '-m', 'ctrl'], () =>
       setTimeout(
-        () => run(['-d', '12', '--', text], () => run(['-k', 'Return'], restoreOverlay)),
+        () => run(['-d', '12', '--', text], () => run(['-k', 'Return'], finish)),
         120
       )
     );

--- a/main.js
+++ b/main.js
@@ -43,6 +43,18 @@ let swayTargetConId = null;
 
 /** True while a Wayland macro is running - see sendMacroWayland. */
 let macroInFlight = false;
+let lastMacroEndedAt = 0;
+
+/**
+ * Quiet period after a macro before another crack is accepted.
+ *
+ * overlay.html fires a crack whenever the whip tip exceeds crackSpeed, with only a
+ * 200ms cooldown - and one flick of the wrist holds the tip above that threshold
+ * for most of a second, so a single whip motion triggers several times. That used
+ * to be invisible because the phrases merged into one prompt; once the Return
+ * started registering properly it turned into several separate messages per whip.
+ */
+const MACRO_REFRACTORY_MS = 800;
 
 function captureSwayFocus() {
   if (process.platform !== 'linux' || !process.env.WAYLAND_DISPLAY) return;
@@ -317,7 +329,7 @@ function sendMacroWayland(text) {
   // their own virtual keyboard and interleave, which shows up as phrases running
   // together with no Enter between them and words truncated mid-word. Drop cracks
   // that arrive while one is still in flight rather than stacking them.
-  if (macroInFlight) return;
+  if (macroInFlight || Date.now() - lastMacroEndedAt < MACRO_REFRACTORY_MS) return;
   macroInFlight = true;
 
   // The overlay is created with alwaysOnTop 'screen-saver', which Electron maps to
@@ -335,6 +347,7 @@ function sendMacroWayland(text) {
     clearTimeout(watchdog);
     if (wasVisible && overlay && !overlay.isDestroyed()) overlay.show();
     macroInFlight = false;
+    lastMacroEndedAt = Date.now();
   };
   // Belt and braces: if wtype ever wedges, this stops one stuck run from leaving
   // the whip permanently unable to crack again.
@@ -352,15 +365,24 @@ function sendMacroWayland(text) {
     });
 
   // Text goes after `--` so a phrase starting with `-` is never read as an option,
-  // and through execFile's argv so there is no shell quoting to get wrong. The
-  // pause lets the interrupted TUI redraw its prompt before we type into it -
-  // without it the first characters land while the app is still tearing down.
-  // The Return is deliberately held back from the typing burst. TUIs that
-  // implement bracketed paste - Claude Code among them - treat a newline arriving
-  // inside a fast input burst as a literal line break rather than a submit, so the
-  // phrase lands in the prompt and just sits there. Successive cracks then pile up
-  // in the same input box and go out as one run-together message. A gap puts the
-  // Return outside the paste window so it registers as a real keypress.
+  // and through execFile's argv so there is no shell quoting to get wrong.
+  //
+  // 120 lets the interrupted TUI redraw its prompt before we type into it, and 150
+  // keeps the Return out of the typing burst so a terminal implementing bracketed
+  // paste reads it as a keypress rather than a pasted line break.
+  //
+  // Both are empirical. Raising them does NOT make this more reliable - that was
+  // measured, not assumed. Whether the Return submits turns out to depend mostly on
+  // what the target app is doing at that instant: it lands reliably against an idle
+  // prompt, and unreliably against one that is mid-render or streaming output, where
+  // the phrase types in but the newline does not submit and the next crack's text
+  // piles in behind it. That is a property of the target, not a constant to tune, so
+  // these are deliberately back at the lowest values that worked.
+  // Ctrl+C, and it has to be Ctrl+C. Escape was tried and is worse: it does not
+  // interrupt, so anything typed during a running operation queues up behind it and
+  // arrives as one batch. The interrupt is not incidental here - it is what returns
+  // the target to an idle prompt, which is the state where the Return actually
+  // submits. No interrupt, no submit.
   const whip = () =>
     run(['-M', 'ctrl', '-k', 'c', '-m', 'ctrl'], () =>
       setTimeout(

--- a/main.js
+++ b/main.js
@@ -355,10 +355,19 @@ function sendMacroWayland(text) {
   // and through execFile's argv so there is no shell quoting to get wrong. The
   // pause lets the interrupted TUI redraw its prompt before we type into it -
   // without it the first characters land while the app is still tearing down.
+  // The Return is deliberately held back from the typing burst. TUIs that
+  // implement bracketed paste - Claude Code among them - treat a newline arriving
+  // inside a fast input burst as a literal line break rather than a submit, so the
+  // phrase lands in the prompt and just sits there. Successive cracks then pile up
+  // in the same input box and go out as one run-together message. A gap puts the
+  // Return outside the paste window so it registers as a real keypress.
   const whip = () =>
     run(['-M', 'ctrl', '-k', 'c', '-m', 'ctrl'], () =>
       setTimeout(
-        () => run(['-d', '12', '--', text], () => run(['-k', 'Return'], finish)),
+        () =>
+          run(['-d', '12', '--', text], () =>
+            setTimeout(() => run(['-k', 'Return'], finish), 150)
+          ),
         120
       )
     );


### PR DESCRIPTION
Makes the whip actually land on Wayland compositors. Tested on sway 1.9 / Ubuntu 24.04 with ghostty.

There are already two open Linux PRs (#34, #37), so to be clear about what is different here: this one needs no root daemon, no group membership and no re-login, and it fixes a second bug that neither addresses.

### 1. `xdotool` cannot reach Wayland clients

`sendMacroLinux` currently shells out to `xdotool`, which drives XTEST. A wlroots compositor does not route XTEST events to Wayland clients, so under sway the macro reaches XWayland windows and nothing else — whipping a Wayland-native terminal silently does nothing at all.

This routes to `wtype(1)` when `WAYLAND_DISPLAY` is set, which speaks the virtual-keyboard Wayland protocol. The existing `xdotool` path is untouched and still used on X11.

`wtype` needs no daemon and no elevated privileges — it is a plain `apt install wtype` / `pacman -S wtype`. That is the main practical difference from #34, which uses `ydotool` and therefore requires `systemctl enable --now ydotool`, `usermod -aG input`, and a logout before it works.

### 2. The overlay swallows the keystrokes

This one took a while to find, and it bites regardless of which input tool you use.

The overlay is created with `setAlwaysOnTop(true, 'screen-saver')`, which Electron maps to a layer-shell surface that holds keyboard interactivity. While the whip is on screen, the compositor routes the virtual keyboard to *that surface* — not to the window it still reports as focused. Every keystroke vanishes into the whip.

The symptom is confusing, because everything looks correct: the right window is focused, and every `wtype`/`ydotool` call exits 0. Nothing arrives. Dropping the surface for the ~200 ms the macro takes is what actually releases the keyboard; it is restored immediately afterwards so the whip survives the crack.

I would expect #34 and #37 to hit this too on any wlroots compositor.

### 3. Focus drifts mid-crack under `focus_follows_mouse`

sway defaults to `focus_follows_mouse=yes`, and cracking a whip means flinging the pointer across the screen — so focus lands on whichever window the cursor passed over, and the macro types there.

The focused container is now recorded on tray click, before the overlay appears or the pointer starts moving, and refocused via `swaymsg` immediately before typing. `refocusPreviousApp`'s Alt+Tab is skipped under Wayland, where it is meaningless: a tiling compositor has no most-recently-used stack to walk, and neither the layer-shell tray nor the `focusable: false` overlay ever takes keyboard focus in the first place.

This part is sway-specific and degrades gracefully — if `swaymsg` is not present (Hyprland, GNOME, ...) it falls through to whatever currently has focus, which is the previous behaviour.

### Notes

- No new dependencies; `wtype` is invoked through `execFile` with an argv array, and the phrase is passed after `--` so a text starting with `-` is never parsed as an option.
- X11 and the Windows/macOS paths are unchanged.
